### PR TITLE
Move security headers into a headers.rules include

### DIFF
--- a/headers.rules
+++ b/headers.rules
@@ -1,3 +1,19 @@
 add_header X-Frame-Options DENY;
 add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
+
+# HTTP Strict Transport Security: tells browsers to require https:// without first checking
+# the http:// version for a redirect. Warning: it is difficult to change your mind.
+# 
+#    max-age: length of requirement in seconds (31536000 = 1 year)
+#    includeSubdomains: force SSL for *ALL* subdomains (remove if this is not what you want)
+#    preload: indicates you want browsers to ship with HSTS preloaded for your domain.
+# 
+#    Submit your domain for preloading in browsers at: https://hstspreload.appspot.com
+
+add_header Strict-Transport-Security 'max-age=31536000';
+
+# If you can turn on HTTPS for *all* subdomains, use this version
+# and submit your domain for preloading:
+#
+# add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';

--- a/headers.rules
+++ b/headers.rules
@@ -1,0 +1,3 @@
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";

--- a/ssl/ssl.rules
+++ b/ssl/ssl.rules
@@ -5,22 +5,6 @@
 ####################################
 
 
-# HTTP Strict Transport Security: tells browsers to require https:// without first checking
-# the http:// version for a redirect. Warning: it is difficult to change your mind.
-# 
-#    max-age: length of requirement in seconds (31536000 = 1 year)
-#    includeSubdomains: force SSL for *ALL* subdomains (remove if this is not what you want)
-#    preload: indicates you want browsers to ship with HSTS preloaded for your domain.
-# 
-#    Submit your domain for preloading in browsers at: https://hstspreload.appspot.com
-
-add_header Strict-Transport-Security 'max-age=31536000';
-
-# If you can turn on HTTPS for *all* subdomains, use this version
-# and submit your domain for preloading:
-#
-# add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
-
 # Prefer certain ciphersuites, to enforce Forward Secrecy and avoid known vulnerabilities.
 #
 # Forces forward secrecy in all browsers and clients that can use TLS,

--- a/vhosts/default.conf
+++ b/vhosts/default.conf
@@ -7,6 +7,9 @@ server {
   listen 80;
   server_name  localhost;
 
+  # should be in server block, contains add_header directives
+  include headers.rules;
+
   location / {
       root   html;
       index  index.html index.htm;
@@ -22,8 +25,9 @@ server {
   ssl_certificate      /etc/nginx/ssl/keys/test.crt;
   ssl_certificate_key  /etc/nginx/ssl/keys/test.key;
 
-  # needs to be at /etc/nginx/ssl/ssl.rules
+  # should be in server block, contains add_header directives
   include ssl/ssl.rules;
+  include headers.rules;
 
   location / {
       root   html;

--- a/vhosts/default.conf
+++ b/vhosts/default.conf
@@ -7,7 +7,9 @@ server {
   listen 80;
   server_name  localhost;
 
-  # should be in server block, contains add_header directives
+  # If add_header directives are used in a location block, that will
+  # override the headers in this include, and this include will need to 
+  # be moved and replicated in *every* location block.
   include headers.rules;
 
   location / {
@@ -25,8 +27,11 @@ server {
   ssl_certificate      /etc/nginx/ssl/keys/test.crt;
   ssl_certificate_key  /etc/nginx/ssl/keys/test.key;
 
-  # should be in server block, contains add_header directives
   include ssl/ssl.rules;
+
+  # If add_header directives are used in a location block, that will
+  # override the headers in this include, and this include will need to 
+  # be moved and replicated in *every* location block.
   include headers.rules;
 
   location / {


### PR DESCRIPTION
This moves the `add_header` directives in a place where they can be easily included in multiple server blocks. Since there was already an `add_header` directive being set at the server block level
in `ssl.rules` (the [HSTS](https://https.cio.gov/hsts/) header), this is necessary in order for the `add_header` directives that set other security headers to be seen at all.

I moved the HSTS `add_header` directive into `headers.rules`, so that the weird `add_header` directive behavior is confined to one directive that can be reasoned about (and replicated if need be) more easily. HSTS is also a security header, and not actually TLS configuration, so it's not out of place.
